### PR TITLE
chore(deps): drop django-action-logger dependency

### DIFF
--- a/apis_ontology/templates/django_action_logger/djangoactionlogentry_list.html
+++ b/apis_ontology/templates/django_action_logger/djangoactionlogentry_list.html
@@ -1,7 +1,0 @@
-{% extends "base.html" %}
-
-{% block content %}
-<div class="container">
-{% include "django_action_logger/logentrylist.html" %}
-</div>
-{% endblock %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ psycopg2 = "^2.9"
 apis-core = {git = "https://github.com/acdh-oeaw/apis-core-rdf", rev = "v0.22.0"}
 apis-highlighter-ng = "^0.4.0"
 apis-acdhch-default-settings = "1.0.0"
-django-action-logger = "^0.1.5"
 django-acdhch-functions = "^0.1.3"
 
 [build-system]


### PR DESCRIPTION
The dependency is not maintained anymore. If the functionality is
needed, it should be replaced with django-auditlog
