### PR TITLE
chore(deps): drop django-acdhch-functions

### DIFF
--- a/apis_ontology/settings.py
+++ b/apis_ontology/settings.py
@@ -6,7 +6,6 @@ INSTALLED_APPS += ["apis_highlighter", "django.contrib.postgres",
                    "apis_core.collections", "apis_core.history"]
 INSTALLED_APPS.remove("apis_ontology")
 INSTALLED_APPS.insert(0, "apis_ontology")
-INSTALLED_APPS += ["django_acdhch_functions"]
 
 ROOT_URLCONF = 'apis_ontology.urls'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ psycopg2 = "^2.9"
 apis-core = {git = "https://github.com/acdh-oeaw/apis-core-rdf", rev = "v0.28.0"}
 apis-highlighter-ng = "^0.4.0"
 apis-acdhch-default-settings = "1.2.1"
-django-acdhch-functions = "^0.1.3"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
This is not needed anymore, part of the functionality is now in the
default-settings.
