### PR TITLE
chore: cleanup settings file

### DIFF
--- a/apis_ontology/settings.py
+++ b/apis_ontology/settings.py
@@ -9,34 +9,7 @@ INSTALLED_APPS.insert(0, "apis_ontology")
 
 ROOT_URLCONF = 'apis_ontology.urls'
 
-ALLOWED_HOSTS = ["mpr.acdh-ch-dev.oeaw.ac.at"]
-
 CSRF_TRUSTED_ORIGINS = ["https://mpr.acdh-ch-dev.oeaw.ac.at"]
 
 
-APIS_LIST_LINKS_TO_EDIT = True
-
-
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    'formatters': {
-        'verbose': {
-            'format': '%(asctime)s %(name)-6s %(levelname)-8s %(message)s',
-        },
-    },
-    "handlers": {
-        "console": {
-            "class": "logging.StreamHandler",
-            "formatter": "verbose",
-        },
-    },
-    "root": {
-        "handlers": ["console"],
-        "level": "DEBUG",
-    },
-}
-
 LANGUAGE_CODE = "de"
-
-APIS_BASE_URI = "https://mpr.acdh-ch-dev.oeaw.ac.at"


### PR DESCRIPTION
The ALLOWED_HOSTS and APIS_BASE_URI are set automatically by the default
settings package
The LOGGING configuration is also part of the default settings package.
The APIS_LIST_LINKS_TO_EDIT setting is not used anymore
