### PR TITLE
fix(templates): update templatetag name

### DIFF
--- a/apis_ontology/templates/apis_core/apis_entities/abstractentity.html
+++ b/apis_ontology/templates/apis_core/apis_entities/abstractentity.html
@@ -1,5 +1,5 @@
 {% extends "apis_core/apis_entities/abstractentity.html" %}
-{% load apis_collections %}
+{% load collections %}
 
 {% block scriptHeader %}
 {{ block.super }}


### PR DESCRIPTION
Recent APIS version renamed the templatetag from apis_collections to
collections.
