### PR TITLE
list of grouping entities in print_index

### DIFF
--- a/data_upgrade/Register_Oberbegriffe_real_or_conceptual.tsv
+++ b/data_upgrade/Register_Oberbegriffe_real_or_conceptual.tsv
@@ -1,0 +1,139 @@
+https://mpr.acdh.oeaw.ac.at/entity/1395	Reichsrat, Parlament	real
+https://mpr.acdh.oeaw.ac.at/entity/1480	Gerichtshof, Oberster	real
+https://mpr.acdh.oeaw.ac.at/entity/1481	Sicherheitswesen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/1530	Landwirtschaft	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/1708	Vatikan conceptual
+https://mpr.acdh.oeaw.ac.at/entity/1911	Sanitätswesen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/1914	Zensur	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/1957	Finanzministerium	real
+https://mpr.acdh.oeaw.ac.at/entity/2008	Justizwesen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/2011	Zollwesen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/2138	Ministerium für öffentliche Arbeiten	real
+https://mpr.acdh.oeaw.ac.at/entity/2248	Abgeordnetenhaus	real
+https://mpr.acdh.oeaw.ac.at/entity/2267	Oesterreichische Nationalbank	real
+https://mpr.acdh.oeaw.ac.at/entity/2641	Ministerratspräsidium	real
+https://mpr.acdh.oeaw.ac.at/entity/2873	Staatsbahnen, österreichische	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/3211	Bewaffnete Macht, gesamte	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/3224	Kirche, römisch-katholische	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/3225	Kirche, griechisch-katholische (griechisch-unierte)	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/3226	Kirche, griechisch-orthodoxe (griechisch nicht unierte)	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/3315	Delegation des Reichsrates	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/3418	Handelsministerium	real
+https://mpr.acdh.oeaw.ac.at/entity/3434	Amt für Volksernährung	real
+https://mpr.acdh.oeaw.ac.at/entity/6774	Handels- und Gewerbekammern	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/6801	Landtag, Böhmen	real
+https://mpr.acdh.oeaw.ac.at/entity/6830	Landtag, Tirol	real
+https://mpr.acdh.oeaw.ac.at/entity/6895	Herrenhaus	real
+https://mpr.acdh.oeaw.ac.at/entity/6984	Landtag, Mähren	real
+https://mpr.acdh.oeaw.ac.at/entity/6995	Zollämter	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/7188	Bürgermeister	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/7368	Gemeinderat (Landtag), Triest	real
+https://mpr.acdh.oeaw.ac.at/entity/7735	Reichstag, Ungarn (ab 1867)	real
+https://mpr.acdh.oeaw.ac.at/entity/7912	Kirche, evangelische	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/7942	Post-, Telegrafenwesen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/8634	Verwaltung, Ungarn	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/9788	Volksschulen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13122	Presse, einzelne Zeitungen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13124	Kreisgerichte	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13126	Vereine	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13150	Juden	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13156	Schulen, höhere	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13160	Kultureinrichtungen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13170	Gemeinderäte	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13172	Banken	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13285	Auszeichnungen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13329	Wirtschaftsunternehmen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13387	Archive	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13400	Finanzwesen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13409	Verwaltung, politische	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13411	Handelsinstitutionen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13455	Militär	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13468	Presse	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13596	Schulräte	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13614	Bezirksvertretungen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13627	Kunst und Kultur	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13680	Regierungen, ausländische	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13682	Regierungen, Deutsches Reich, Reich und Länder	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13728	Landesverwaltungen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13796	Handelsangelegenheiten	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13797	Statistik	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13814	Geldwesen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13840	Regierungsmitglieder, Cisleithanien	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13845	Regierungsmitglieder, Kaisertum Österreich	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13847	Regierungsmitglieder, Ungarn	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13856	Bildungswesen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13859	Bauwesen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13863	Advokatenkammern	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13871	Eigentum, öffentliches	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/13915	Missionen in auswärtigen Staaten	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14001	Finanzbezirksdirektionen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14310	Bildungseinrichtungen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14315	Steuerwesen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14344	Bezirkshauptleute	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14345	Bezirkshauptmannschaften	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14366	Post- und Telegrafendirektionen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14378	Eisenbahnwesen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14394	Wahlinstitutionen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14398	Landesausschüsse	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14445	Maße und Gewichte	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14451	Privat-, Familienbesitz	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14460	Besitzverhältnisse	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14462	Bewegungen, politische	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14474	Universitäten, Hochschulen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14479	Ausstellungen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14489	Kirchen, Religionen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14492	Soziale Fürsorge	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14537	Landeschefs	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14538	Parlamente, Deutsches Reich und Länder	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14542	Landtagskommissäre	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14556	Gerichtspräsidenten	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14560	Mitteilungen, offizielle	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14735	Schifffahrt	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14774	Bezirksämter	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14777	Finanzlandes-, Finanzdirektionen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14782	Finanzprokuraturen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14792	Gerichtshöfe I. Instanz	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14798	Kirche, hussitische	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14800	Bezirksgerichte	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14803	Landesgerichte	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14806	Reichsgericht	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14808	Staatsanwaltschaften	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14812	Statthaltereien	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14866	Verkehrswesen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14882	Oberlandesgerichte	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14896	Landtage	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/16577	Niederösterreich	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/17065	Tabakwesen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/17089	Bergwesen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/17129	Gesundheitswesen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/17142	Forstwesen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/17146	Konsulate	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/17150	Stadträte	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/17152	Kriegswirtschaft	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/17163	Theorien	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/17166	Ideologien und Denkrichtungen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/17200	Kriegssicherheitsmaßnahmen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/17206	Arbeitervertretungen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/17754	Sozialversicherungen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/17945	Bosnien-Herzegowina	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/17946	Verwaltung, Bosnien-Herzegowina	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/18580	Propinationsfonds	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/18677	Grundentlastungsfonds	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/18684	Gemeindeausschüsse	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/18737	Privatschulen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/18802	Wahlbezirke	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/18819	Vertretungen in Österreich-Ungarn, ausländische	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/19870	Finanzinspektorate	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/19887	Handelskammern, Preußen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/19963	Beschwerdekommissionen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/19976	Arbeitswesen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/19994	Wohnwesen	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/20026	Adel	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/20279	Approvisionierung	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/20494	Sozialpolitik	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/20523	Wirtschaftsverbände	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/20534	Parlamente, ausländische	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/21427	Regierungen und Nationalräte der Übergangsphase	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/21430	Regierungen, Exil	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/2633	Eisenbahnlinien	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/6019	k. k. Kreisgericht in Cilli	real

--- a/data_upgrade/Register_Oberbegriffe_real_or_conceptual.tsv
+++ b/data_upgrade/Register_Oberbegriffe_real_or_conceptual.tsv
@@ -73,7 +73,6 @@ https://mpr.acdh.oeaw.ac.at/entity/14344	Bezirkshauptleute	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/14345	Bezirkshauptmannschaften	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/14366	Post- und Telegrafendirektionen	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/14378	Eisenbahnwesen	conceptual
-https://mpr.acdh.oeaw.ac.at/entity/14394	Wahlinstitutionen	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/14398	Landesausschüsse	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/14445	Maße und Gewichte	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/14451	Privat-, Familienbesitz	conceptual
@@ -86,17 +85,14 @@ https://mpr.acdh.oeaw.ac.at/entity/14492	Soziale Fürsorge	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/14537	Landeschefs	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/14538	Parlamente, Deutsches Reich und Länder	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/14542	Landtagskommissäre	conceptual
-https://mpr.acdh.oeaw.ac.at/entity/14556	Gerichtspräsidenten	conceptual
-https://mpr.acdh.oeaw.ac.at/entity/14560	Mitteilungen, offizielle	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/14735	Schifffahrt	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/14774	Bezirksämter	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/14777	Finanzlandes-, Finanzdirektionen	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/14782	Finanzprokuraturen	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/14792	Gerichtshöfe I. Instanz	conceptual
-https://mpr.acdh.oeaw.ac.at/entity/14798	Kirche, hussitische	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/14800	Bezirksgerichte	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/14803	Landesgerichte	conceptual
-https://mpr.acdh.oeaw.ac.at/entity/14806	Reichsgericht	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/14806	Reichsgericht	real
 https://mpr.acdh.oeaw.ac.at/entity/14808	Staatsanwaltschaften	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/14812	Statthaltereien	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/14866	Verkehrswesen	conceptual
@@ -111,7 +107,6 @@ https://mpr.acdh.oeaw.ac.at/entity/17146	Konsulate	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/17150	Stadträte	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/17152	Kriegswirtschaft	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/17163	Theorien	conceptual
-https://mpr.acdh.oeaw.ac.at/entity/17166	Ideologien und Denkrichtungen	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/17200	Kriegssicherheitsmaßnahmen	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/17206	Arbeitervertretungen	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/17754	Sozialversicherungen	conceptual

--- a/data_upgrade/Register_Oberbegriffe_real_or_conceptual.tsv
+++ b/data_upgrade/Register_Oberbegriffe_real_or_conceptual.tsv
@@ -12,7 +12,7 @@ https://mpr.acdh.oeaw.ac.at/entity/2138	Ministerium für öffentliche Arbeiten	r
 https://mpr.acdh.oeaw.ac.at/entity/2248	Abgeordnetenhaus	real
 https://mpr.acdh.oeaw.ac.at/entity/2267	Oesterreichische Nationalbank	real
 https://mpr.acdh.oeaw.ac.at/entity/2641	Ministerratspräsidium	real
-https://mpr.acdh.oeaw.ac.at/entity/2873	Staatsbahnen, österreichische	conceptual
+https://mpr.acdh.oeaw.ac.at/entity/2873	Staatsbahnen, österreichische	real
 https://mpr.acdh.oeaw.ac.at/entity/3211	Bewaffnete Macht, gesamte	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/3224	Kirche, römisch-katholische	conceptual
 https://mpr.acdh.oeaw.ac.at/entity/3225	Kirche, griechisch-katholische (griechisch-unierte)	conceptual


### PR DESCRIPTION
This adds a list for deciding 

- whether or not some **institution** entities are factual/"real" entities that we want in the restructured database
- whether or not to import the relation itself.

Background for @b1rger: MRP used a workaround to group entities in the printed index. Entities were created for the sole purpose of grouping (123 of 139 that have the relation type https://mpr.acdh.oeaw.ac.at/apis/api/vocabularies/institutioninstitutionrelation/539/ "Ist Oberbegriff von (Register)" are conceptual), while in 16 cases existing real entities have been used for the same purpose. 

Examples: "Oesterreichische Nationalbank" vs. "Sicherheitswesen"

Only the "real" entities should be imported as institutions. For the "conceptual" grouping entities, another solution has to be found (A separate entity type? A JSON field property?). As discovered with @sennierer yesterday, there was no way to distinguish between the two, hence this list.